### PR TITLE
Fix Go 1.15.2 version environment variable

### DIFF
--- a/docker/go-1.15.2/Dockerfile
+++ b/docker/go-1.15.2/Dockerfile
@@ -1,7 +1,7 @@
 FROM techknowlogick/xgo:base
 
 # Configure the root Go distribution and bootstrap based on it
-ENV GO_VERSION 1151
+ENV GO_VERSION 1152
 
 RUN \
   export ROOT_DIST=https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz && \


### PR DESCRIPTION
Bump GO_VERSION to match other 1.15.2 release changes.

I saw this while exploring how xgo works.

refs techknowlogick/xgo#80