### PR TITLE
bug/build-chown: limiting chown-ed files in build.sh

### DIFF
--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -450,5 +450,5 @@ for dir in `ls /usr/local`; do
   fi
 done
 
-# set owner of created executables to owner of the /build direcotry
-chown -R --reference /build /build/*
+# set owner of created executables to owner of the /build directory (all executables and created directories start with $NAME)
+chown -R --reference /build /build/"$NAME"*


### PR DESCRIPTION
chown-ing the whole /build directory creates issues when running xgo in an environment with limited privileges (eg. most CIs).
As specified by the comment above the command, the purpose of this chown is to

> set owner of created executables to owner of the /build directory

and since all executables start with `$NAME`, I think it's safe to limit which files are being chown-ed to the ones created by `build.sh`