### PR TITLE
Use build.Default.GOPATH instead of os.Env("GOPATH") in modules

### DIFF
--- a/xgo.go
+++ b/xgo.go
@@ -350,7 +350,7 @@ func compile(image string, config *ConfigFlags, flags *BuildFlags, folder string
 	}
 	if usesModules {
 		args = append(args, []string{"-e", "GO111MODULE=on"}...)
-		args = append(args, []string{"-v", os.Getenv("GOPATH") + ":/go"}...)
+		args = append(args, []string{"-v", build.Default.GOPATH + ":/go"}...)
 
 		// Map this repository to the /source folder
 		absRepository, err := filepath.Abs(config.Repository)


### PR DESCRIPTION
When using modules it is not guaranteed that GOPATH will be set, instead
use the build.Default.GOPATH which will be overriden by os.Env when
GOPATH is set, but will still be a reasonable path if not.

Signed-off-by: Andrew Thornton <art27@cantab.net>