### PR TITLE
Use build.Default.GOPATH in non-modules paths too

### DIFF
--- a/xgo.go
+++ b/xgo.go
@@ -266,12 +266,18 @@ func compile(image string, config *ConfigFlags, flags *BuildFlags, folder string
 		_, err := os.Stat(modFile)
 		usesModules = !os.IsNotExist(err)
 
+		gopathEnv := os.Getenv("GOPATH")
+		if gopathEnv == "" && !usesModules {
+			log.Printf("No $GOPATH is set - defaulting to %s", build.Default.GOPATH)
+			gopathEnv = build.Default.GOPATH
+		}
+
 		// Iterate over all the local libs and export the mount points
-		if os.Getenv("GOPATH") == "" && !usesModules {
+		if gopathEnv == "" && !usesModules {
 			log.Fatalf("No $GOPATH is set or forwarded to xgo")
 		}
 		if !usesModules {
-			for _, gopath := range strings.Split(os.Getenv("GOPATH"), string(os.PathListSeparator)) {
+			for _, gopath := range strings.Split(gopathEnv, string(os.PathListSeparator)) {
 				// Since docker sandboxes volumes, resolve any symlinks manually
 				sources := filepath.Join(gopath, "src")
 				filepath.Walk(sources, func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
Signed-off-by: Andrew Thornton <art27@cantab.net>