### PR TITLE
solve the issue [on windows execute "xgo --targets=linux/amd64 ."] ca…

### DIFF
--- a/xgo.go
+++ b/xgo.go
@@ -317,13 +317,13 @@ func compile(image string, config *ConfigFlags, flags *BuildFlags, folder string
 					// Folder needs explicit mounting due to docker symlink security
 					locals = append(locals, target)
 					mounts = append(mounts, filepath.Join("/ext-go", strconv.Itoa(len(locals)), "src", strings.TrimPrefix(path, sources)))
-					paths = append(paths, filepath.Join("/ext-go", strconv.Itoa(len(locals))))
+					paths = append(paths, filepath.ToSlash(filepath.Join("/ext-go", strconv.Itoa(len(locals)))))
 					return nil
 				})
 				// Export the main mount point for this GOPATH entry
 				locals = append(locals, sources)
 				mounts = append(mounts, filepath.Join("/ext-go", strconv.Itoa(len(locals)), "src"))
-				paths = append(paths, filepath.Join("/ext-go", strconv.Itoa(len(locals))))
+				paths = append(paths, filepath.ToSlash(filepath.Join("/ext-go", strconv.Itoa(len(locals)))))
 			}
 		}
 	}


### PR DESCRIPTION
…use-- GOPATH entry is relative; must be absolute path: "\\ext-go\\1".