### PR TITLE
Adjust go111modules detection and fix lint

### DIFF
--- a/docker/base/bootstrap_pure.sh
+++ b/docker/base/bootstrap_pure.sh
@@ -17,10 +17,10 @@ set -e
 
 # Download, verify and install the root distribution if pulled remotely
 if [ "$GOROOT" == "" ]; then
-  $FETCH $ROOT_DIST $ROOT_DIST_SHA
+  $FETCH "$ROOT_DIST" "$ROOT_DIST_SHA"
 
-  tar -C /usr/local -xzf `basename $ROOT_DIST`
-  rm -f `basename $ROOT_DIST`
+  tar -C /usr/local -xzf "$(basename "$ROOT_DIST")"
+  rm -f "$(basename "$ROOT_DIST")"
 
   export GOROOT=/usr/local/go
 fi

--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -74,8 +74,9 @@ if [ "$EXT_GOPATH" != "" ]; then
   set -e
 
   # Find and change into the package folder
-  cd `go list -e -f {{.Dir}} $1`
-  export GOPATH=$GOPATH:`pwd`/Godeps/_workspace
+  cd "$(go list -e -f "{{.Dir}}" "$1")"
+  GODEPS_WORKSPACE="$(pwd)/Godeps/_workspace"
+  export GOPATH="$GOPATH":"$GODEPS_WORKSPACE"
 elif [[ "$USEMODULES" == true ]]; then
   # Go module builds should assume a local repository
   # at mapped to /source containing at least a go.mod file.
@@ -88,19 +89,19 @@ elif [[ "$USEMODULES" == true ]]; then
   echo "Building /source/go.mod..."
 else
   # Inject all possible Godep paths to short circuit go gets
-  GOPATH_ROOT=$GOPATH/src
-  IMPORT_PATH=$1
+  GOPATH_ROOT="$GOPATH/src"
+  IMPORT_PATH="$1"
   while [ "$IMPORT_PATH" != "." ]; do
-    export GOPATH=$GOPATH:$GOPATH_ROOT/$IMPORT_PATH/Godeps/_workspace
-    IMPORT_PATH=`dirname $IMPORT_PATH`
+    export GOPATH="$GOPATH":"$GOPATH_ROOT/$IMPORT_PATH"/Godeps/_workspace
+    IMPORT_PATH=$(dirname "$IMPORT_PATH")
   done
 
   # Otherwise download the canonical import path (may fail, don't allow failures beyond)
   echo "Fetching main repository $1..."
-  go get -v -d $1
+  go get -v -d "$1"
   set -e
 
-  cd $GOPATH_ROOT/$1
+  cd "$GOPATH_ROOT/$1"
 
   # Switch over the code-base to another checkout if requested
   if [ "$REPO_REMOTE" != "" ] || [ "$REPO_BRANCH" != "" ]; then
@@ -112,18 +113,18 @@ else
       elif  [ -d "$GOPATH_ROOT/$IMPORT_PATH/.hg" ]; then
         REPO_TYPE="hg"
       fi
-      IMPORT_PATH=`dirname $IMPORT_PATH`
+      IMPORT_PATH=$(dirname "$IMPORT_PATH")
     done
 
     if [ "$REPO_TYPE" == "" ]; then
       echo "Unknown version control system type, cannot switch remotes and branches."
-      exit -1
+      exit 255
     fi
     # If we have a valid VCS, execute the switch operations
     if [ "$REPO_REMOTE" != "" ]; then
       echo "Switching over to remote $REPO_REMOTE..."
       if [ "$REPO_TYPE" == "git" ]; then
-        git remote set-url origin $REPO_REMOTE
+        git remote set-url origin "$REPO_REMOTE"
         git fetch --all
         git reset --hard origin/HEAD
         git clean -dxf
@@ -135,10 +136,10 @@ else
     if [ "$REPO_BRANCH" != "" ]; then
       echo "Switching over to branch $REPO_BRANCH..."
       if [ "$REPO_TYPE" == "git" ]; then
-        git reset --hard origin/$REPO_BRANCH
+        git reset --hard "origin/$REPO_BRANCH"
         git clean -dxf
       elif [ "$REPO_TYPE" == "hg" ]; then
-        hg checkout $REPO_BRANCH
+        hg checkout "$REPO_BRANCH"
       fi
     fi
   fi
@@ -146,24 +147,27 @@ fi
 
 # Download all the C dependencies
 mkdir /deps
-DEPS=($DEPS) && for dep in "${DEPS[@]}"; do
-  if [ "${dep##*.}" == "tar" ]; then cat "/deps-cache/`basename $dep`" | tar -C /deps -x; fi
-  if [ "${dep##*.}" == "gz" ];  then cat "/deps-cache/`basename $dep`" | tar -C /deps -xz; fi
-  if [ "${dep##*.}" == "bz2" ]; then cat "/deps-cache/`basename $dep`" | tar -C /deps -xj; fi
+DEPS=("$DEPS") && for dep in "${DEPS[@]}"; do
+  if [ "${dep##*.}" == "tar" ]; then tar -C /deps -x < "/deps-cache/$(basename "$dep")"; fi
+  if [ "${dep##*.}" == "gz" ];  then tar -C /deps -xz < "/deps-cache/$(basename "$dep")"; fi
+  if [ "${dep##*.}" == "bz2" ]; then tar -C /deps -xj < "/deps-cache/$(basename "$dep")"; fi
 done
 
-DEPS_ARGS=($ARGS)
+DEPS_ARGS=("$ARGS")
 
 # Save the contents of the pre-build /usr/local folder for post cleanup
-USR_LOCAL_CONTENTS=`ls /usr/local`
+shopt -s nullglob
+USR_LOCAL_CONTENTS=(/home/andrew/*)
+shopt -u nullglob
+
 
 # Configure some global build parameters
-NAME=`basename $1/$PACK`
+NAME=$(basename "$1/$PACK")
 
 # Go module-based builds error with 'cannot find main module'
 # when $PACK is defined
 if [[ "$USEMODULES" = true ]]; then
-  NAME=`sed -n 's/module\ \(.*\)/\1/p' /source/go.mod`
+  NAME=$(sed -n 's/module\ \(.*\)/\1/p' /source/go.mod)
 fi
 
 # Support go module package
@@ -192,45 +196,45 @@ fi
 # Build for each requested platform individually
 for TARGET in $TARGETS; do
   # Split the target into platform and architecture
-  XGOOS=`echo $TARGET | cut -d '/' -f 1`
-  XGOARCH=`echo $TARGET | cut -d '/' -f 2`
+  XGOOS=$(echo $TARGET | cut -d '/' -f 1)
+  XGOARCH=$(echo $TARGET | cut -d '/' -f 2)
 
   # Check and build for Linux targets
-  if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]); then
+  if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "amd64" ]; }; then
     echo "Compiling for linux/amd64..."
-    HOST=x86_64-linux PREFIX=/usr/local $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+    HOST=x86_64-linux PREFIX=/usr/local $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
     if [[ "$USEMODULES" == false ]]; then
-      GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+      GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
     fi
-    GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $R $BM -o "/build/$NAME-linux-amd64$R`extension linux`" $PACK_RELPATH
+    GOOS=linux GOARCH=amd64 CGO_ENABLED=1 go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $R "$BM" -o "/build/$NAME-linux-amd64$R$(extension linux)" "$PACK_RELPATH"
   fi
-  if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "386" ]); then
+  if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "386" ]; }; then
     echo "Compiling for linux/386..."
-    CC="gcc -m32" CXX="g++ -m32" HOST=i686-linux PREFIX=/usr/local $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+    CC="gcc -m32" CXX="g++ -m32" HOST=i686-linux PREFIX=/usr/local $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
     if [[ "$USEMODULES" == false ]]; then
-      GOOS=linux GOARCH=386 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+      GOOS=linux GOARCH=386 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
     fi
-    GOOS=linux GOARCH=386 CGO_ENABLED=1 go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-linux-386`extension linux`" $PACK_RELPATH
+    GOOS=linux GOARCH=386 CGO_ENABLED=1 go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" "$BM" -o "/build/$NAME-linux-386$(extension linux)" "$PACK_RELPATH"
   fi
-  if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "arm" ] || [ $XGOARCH == "arm-5" ]); then
+  if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; }  && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "arm" ] || [ "$XGOARCH" == "arm-5" ]; }; then
     if [ "$GO_VERSION_MAJOR" -gt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -ge 15 ]; }; then
       echo "Bootstrapping linux/arm-5..."
       CC=arm-linux-gnueabi-gcc-6 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go install std
     fi
     echo "Compiling for linux/arm-5..."
-    CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 HOST=arm-linux-gnueabi PREFIX=/usr/arm-linux-gnueabi CFLAGS="-march=armv5" CXXFLAGS="-march=armv5" $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+    CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 HOST=arm-linux-gnueabi PREFIX=/usr/arm-linux-gnueabi CFLAGS="-march=armv5" CXXFLAGS="-march=armv5" $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
     export PKG_CONFIG_PATH=/usr/arm-linux-gnueabi/lib/pkgconfig
 
     if [[ "$USEMODULES" == false ]]; then
-      CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+      CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
     fi
-    CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-linux-arm-5`extension linux`" $PACK_RELPATH
+    CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" "$BM" -o "/build/$NAME-linux-arm-5$(extension linux)" "$PACK_RELPATH"
     if [ "$GO_VERSION_MAJOR" -gt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -ge 15 ]; }; then
       echo "Cleaning up Go runtime for linux/arm-5..."
       rm -rf /usr/local/go/pkg/linux_arm
     fi
   fi
-  if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "arm-6" ]); then
+  if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "arm-6" ]; }; then
     if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 15 ]; }; then
       echo "Go version too low, skipping linux/arm-6..."
     else
@@ -238,19 +242,19 @@ for TARGET in $TARGETS; do
       CC=arm-linux-gnueabi-gcc-6 GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=1 CGO_CFLAGS="-march=armv6" CGO_CXXFLAGS="-march=armv6" go install std
 
       echo "Compiling for linux/arm-6..."
-      CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 HOST=arm-linux-gnueabi PREFIX=/usr/arm-linux-gnueabi CFLAGS="-march=armv6" CXXFLAGS="-march=armv6" $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 HOST=arm-linux-gnueabi PREFIX=/usr/arm-linux-gnueabi CFLAGS="-march=armv6" CXXFLAGS="-march=armv6" $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
       export PKG_CONFIG_PATH=/usr/arm-linux-gnueabi/lib/pkgconfig
 
       if [[ "$USEMODULES" == false ]]; then
-        CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=1 CGO_CFLAGS="-march=armv6" CGO_CXXFLAGS="-march=armv6" go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+        CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=1 CGO_CFLAGS="-march=armv6" CGO_CXXFLAGS="-march=armv6" go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
       fi
-      CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=1 CGO_CFLAGS="-march=armv6" CGO_CXXFLAGS="-march=armv6" go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-linux-arm-6`extension linux`" $PACK_RELPATH
+      CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=1 CGO_CFLAGS="-march=armv6" CGO_CXXFLAGS="-march=armv6" go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" "$BM" -o "/build/$NAME-linux-arm-6$(extension linux)" "$PACK_RELPATH"
 
       echo "Cleaning up Go runtime for linux/arm-6..."
       rm -rf /usr/local/go/pkg/linux_arm
     fi
   fi
-  if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "arm-7" ]); then
+  if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "arm-7" ]; }; then
     if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 15 ]; }; then
       echo "Go version too low, skipping linux/arm-7..."
     else
@@ -258,170 +262,170 @@ for TARGET in $TARGETS; do
       CC=arm-linux-gnueabihf-gcc-6 GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="-march=armv7-a" CGO_CXXFLAGS="-march=armv7-a" go install std
 
       echo "Compiling for linux/arm-7..."
-      CC=arm-linux-gnueabihf-gcc-6 CXX=arm-linux-gnueabihf-g++-6 HOST=arm-linux-gnueabihf PREFIX=/usr/arm-linux-gnueabihf CFLAGS="-march=armv7-a -fPIC" CXXFLAGS="-march=armv7-a -fPIC" $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=arm-linux-gnueabihf-gcc-6 CXX=arm-linux-gnueabihf-g++-6 HOST=arm-linux-gnueabihf PREFIX=/usr/arm-linux-gnueabihf CFLAGS="-march=armv7-a -fPIC" CXXFLAGS="-march=armv7-a -fPIC" $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
       export PKG_CONFIG_PATH=/usr/arm-linux-gnueabihf/lib/pkgconfig
 
       if [[ "$USEMODULES" == false ]]; then
-        CC=arm-linux-gnueabihf-gcc-6 CXX=arm-linux-gnueabihf-g++-6 GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="-march=armv7-a -fPIC" CGO_CXXFLAGS="-march=armv7-a -fPIC" go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+        CC=arm-linux-gnueabihf-gcc-6 CXX=arm-linux-gnueabihf-g++-6 GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="-march=armv7-a -fPIC" CGO_CXXFLAGS="-march=armv7-a -fPIC" go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
       fi
-      CC=arm-linux-gnueabihf-gcc-6 CXX=arm-linux-gnueabihf-g++-6 GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="-march=armv7-a -fPIC" CGO_CXXFLAGS="-march=armv7-a -fPIC" go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-linux-arm-7`extension linux`" $PACK_RELPATH
+      CC=arm-linux-gnueabihf-gcc-6 CXX=arm-linux-gnueabihf-g++-6 GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="-march=armv7-a -fPIC" CGO_CXXFLAGS="-march=armv7-a -fPIC" go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" "$BM" -o "/build/$NAME-linux-arm-7$(extension linux)" "$PACK_RELPATH"
 
       echo "Cleaning up Go runtime for linux/arm-7..."
       rm -rf /usr/local/go/pkg/linux_arm
     fi
   fi
-  if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "arm64" ]); then
+  if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "arm64" ]; }; then
     if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 15 ]; }; then
       echo "Go version too low, skipping linux/arm64..."
     else
       echo "Compiling for linux/arm64..."
-      CC=aarch64-linux-gnu-gcc-6 CXX=aarch64-linux-gnu-g++-6 HOST=aarch64-linux-gnu PREFIX=/usr/aarch64-linux-gnu $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=aarch64-linux-gnu-gcc-6 CXX=aarch64-linux-gnu-g++-6 HOST=aarch64-linux-gnu PREFIX=/usr/aarch64-linux-gnu $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
       export PKG_CONFIG_PATH=/usr/aarch64-linux-gnu/lib/pkgconfig
 
        if [[ "$USEMODULES" == false ]]; then
-        CC=aarch64-linux-gnu-gcc-6 CXX=aarch64-linux-gnu-g++-6 GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+        CC=aarch64-linux-gnu-gcc-6 CXX=aarch64-linux-gnu-g++-6 GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
       fi
-      CC=aarch64-linux-gnu-gcc-6 CXX=aarch64-linux-gnu-g++-6 GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-linux-arm64`extension linux`" $PACK_RELPATH
+      CC=aarch64-linux-gnu-gcc-6 CXX=aarch64-linux-gnu-g++-6 GOOS=linux GOARCH=arm64 CGO_ENABLED=1 go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" "$BM" -o "/build/$NAME-linux-arm64$(extension linux)" "$PACK_RELPATH"
     fi
   fi
-  if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "mips64" ]); then
+  if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "mips64" ]; }; then
     if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 17 ]; }; then
       echo "Go version too low, skipping linux/mips64..."
     else
       echo "Compiling for linux/mips64..."
-      CC=mips64-linux-gnuabi64-gcc-6 CXX=mips64-linux-gnuabi64-g++-6 HOST=mips64-linux-gnuabi64 PREFIX=/usr/mips64-linux-gnuabi64 $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=mips64-linux-gnuabi64-gcc-6 CXX=mips64-linux-gnuabi64-g++-6 HOST=mips64-linux-gnuabi64 PREFIX=/usr/mips64-linux-gnuabi64 $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
       export PKG_CONFIG_PATH=/usr/mips64-linux-gnuabi64/lib/pkgconfig
 
             if [[ "$USEMODULES" == false ]]; then
-        CC=mips64-linux-gnuabi64-gcc-6 CXX=mips64-linux-gnuabi64-g++-6 GOOS=linux GOARCH=mips64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+        CC=mips64-linux-gnuabi64-gcc-6 CXX=mips64-linux-gnuabi64-g++-6 GOOS=linux GOARCH=mips64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
       fi
-      CC=mips64-linux-gnuabi64-gcc-6 CXX=mips64-linux-gnuabi64-g++-6 GOOS=linux GOARCH=mips64 CGO_ENABLED=1 go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-linux-mips64`extension linux`" $PACK_RELPATH
+      CC=mips64-linux-gnuabi64-gcc-6 CXX=mips64-linux-gnuabi64-g++-6 GOOS=linux GOARCH=mips64 CGO_ENABLED=1 go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" "$BM" -o "/build/$NAME-linux-mips64$(extension linux)" "$PACK_RELPATH"
     fi
   fi
-  if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "mips64le" ]); then
+  if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "mips64le" ]; }; then
     if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 17 ]; }; then
       echo "Go version too low, skipping linux/mips64le..."
     else
       echo "Compiling for linux/mips64le..."
-      CC=mips64el-linux-gnuabi64-gcc-6 CXX=mips64el-linux-gnuabi64-g++-6 HOST=mips64el-linux-gnuabi64 PREFIX=/usr/mips64el-linux-gnuabi64 $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=mips64el-linux-gnuabi64-gcc-6 CXX=mips64el-linux-gnuabi64-g++-6 HOST=mips64el-linux-gnuabi64 PREFIX=/usr/mips64el-linux-gnuabi64 $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
       export PKG_CONFIG_PATH=/usr/mips64le-linux-gnuabi64/lib/pkgconfig
 
       if [[ "$USEMODULES" == false ]]; then
-        CC=mips64el-linux-gnuabi64-gcc-6 CXX=mips64el-linux-gnuabi64-g++-6 GOOS=linux GOARCH=mips64le CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+        CC=mips64el-linux-gnuabi64-gcc-6 CXX=mips64el-linux-gnuabi64-g++-6 GOOS=linux GOARCH=mips64le CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
       fi
-      CC=mips64el-linux-gnuabi64-gcc-6 CXX=mips64el-linux-gnuabi64-g++-6 GOOS=linux GOARCH=mips64le CGO_ENABLED=1 go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-linux-mips64le`extension linux`" $PACK_RELPATH
+      CC=mips64el-linux-gnuabi64-gcc-6 CXX=mips64el-linux-gnuabi64-g++-6 GOOS=linux GOARCH=mips64le CGO_ENABLED=1 go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" "$BM" -o "/build/$NAME-linux-mips64le$(extension linux)" "$PACK_RELPATH"
     fi
   fi
-  if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "mips" ]); then
+  if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "mips" ]; }; then
     if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 18 ]; }; then
       echo "Go version too low, skipping linux/mips..."
     else
       echo "Compiling for linux/mips..."
-      CC=mips-linux-gnu-gcc-6 CXX=mips-linux-gnu-g++-6 HOST=mips-linux-gnu PREFIX=/usr/mips-linux-gnu $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=mips-linux-gnu-gcc-6 CXX=mips-linux-gnu-g++-6 HOST=mips-linux-gnu PREFIX=/usr/mips-linux-gnu $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
       export PKG_CONFIG_PATH=/usr/mips-linux-gnu/lib/pkgconfig
 
       if [[ "$USEMODULES" == false ]]; then
-        CC=mips-linux-gnu-gcc-6 CXX=mips-linux-gnu-g++-6 GOOS=linux GOARCH=mips CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+        CC=mips-linux-gnu-gcc-6 CXX=mips-linux-gnu-g++-6 GOOS=linux GOARCH=mips CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
       fi
-      CC=mips-linux-gnu-gcc-6 CXX=mips-linux-gnu-g++-6 GOOS=linux GOARCH=mips CGO_ENABLED=1 go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-linux-mips`extension linux`" $PACK_RELPATH
+      CC=mips-linux-gnu-gcc-6 CXX=mips-linux-gnu-g++-6 GOOS=linux GOARCH=mips CGO_ENABLED=1 go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" "$BM" -o "/build/$NAME-linux-mips$(extension linux)" "$PACK_RELPATH"
     fi
   fi
-  if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "s390x" ]); then
+  if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "s390x" ]; }; then
     if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 17 ]; }; then
       echo "Go version too low, skipping linux/s390x..."
     else
       echo "Compiling for linux/s390x..."
-      CC=s390x-linux-gnu-gcc-6 CXX=s390x-linux-gnu-g++-6 HOST=s390x-linux-gnu PREFIX=/usr/s390x-linux-gnu $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=s390x-linux-gnu-gcc-6 CXX=s390x-linux-gnu-g++-6 HOST=s390x-linux-gnu PREFIX=/usr/s390x-linux-gnu $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
       export PKG_CONFIG_PATH=/usr/s390x-linux-gnu/lib/pkgconfig
 
       if [[ "$USEMODULES" == false ]]; then
-        CC=s390x-linux-gnu-gcc-6 CXX=s390x-linux-gnu-g++-6 GOOS=linux GOARCH=s390x CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+        CC=s390x-linux-gnu-gcc-6 CXX=s390x-linux-gnu-g++-6 GOOS=linux GOARCH=s390x CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
       fi
-      CC=s390x-linux-gnu-gcc-6 CXX=s390x-linux-gnu-g++-6 GOOS=linux GOARCH=s390x CGO_ENABLED=1 go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-linux-s390x`extension linux`" $PACK_RELPATH
+      CC=s390x-linux-gnu-gcc-6 CXX=s390x-linux-gnu-g++-6 GOOS=linux GOARCH=s390x CGO_ENABLED=1 go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" "$BM" -o "/build/$NAME-linux-s390x$(extension linux)" "$PACK_RELPATH"
     fi
   fi
-  if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "riscv64" ]); then
+  if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "riscv64" ]; }; then
     if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 18 ]; }; then
       echo "Go version too low, skipping linux/riscv64..."
     else
       echo "Compiling for linux/riscv64..."
-      CC=riscv64-linux-gnu-gcc-8 CXX=riscv64-linux-gnu-g++-8 HOST=riscv64-linux-gnu PREFIX=/usr/riscv64-linux-gnu $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=riscv64-linux-gnu-gcc-8 CXX=riscv64-linux-gnu-g++-8 HOST=riscv64-linux-gnu PREFIX=/usr/riscv64-linux-gnu $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
       export PKG_CONFIG_PATH=/usr/riscv64-linux-gnu/lib/pkgconfig
 
       if [[ "$USEMODULES" == false ]]; then
-        CC=riscv64-linux-gnu-gcc-8 CXX=riscv64-linux-gnu-g++-8 GOOS=linux GOARCH=riscv64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+        CC=riscv64-linux-gnu-gcc-8 CXX=riscv64-linux-gnu-g++-8 GOOS=linux GOARCH=riscv64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
       fi
-      CC=riscv64-linux-gnu-gcc-8 CXX=riscv64-linux-gnu-g++-8 GOOS=linux GOARCH=riscv64 CGO_ENABLED=1 go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-linux-riscv64`extension linux`" $PACK_RELPATH
+      CC=riscv64-linux-gnu-gcc-8 CXX=riscv64-linux-gnu-g++-8 GOOS=linux GOARCH=riscv64 CGO_ENABLED=1 go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" "$BM" -o "/build/$NAME-linux-riscv64$(extension linux)" "$PACK_RELPATH"
     fi
   fi
-  if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "ppc64le" ]); then
+  if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "ppc64le" ]; }; then
     if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 17 ]; }; then
       echo "Go version too low, skipping linux/ppc64le..."
     else
       echo "Compiling for linux/ppc64le..."
-      CC=powerpc64le-linux-gnu-gcc-6 CXX=powerpc64le-linux-gnu-g++-6 HOST=ppc64le-linux-gnu PREFIX=/usr/ppc64le-linux-gnu $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=powerpc64le-linux-gnu-gcc-6 CXX=powerpc64le-linux-gnu-g++-6 HOST=ppc64le-linux-gnu PREFIX=/usr/ppc64le-linux-gnu $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
       export PKG_CONFIG_PATH=/usr/ppc64le-linux-gnu/lib/pkgconfig
 
       if [[ "$USEMODULES" == false ]]; then
-        CC=powerpc64le-linux-gnu-gcc-6 CXX=powerpc64le-linux-gnu-g++-6 GOOS=linux GOARCH=ppc64le CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+        CC=powerpc64le-linux-gnu-gcc-6 CXX=powerpc64le-linux-gnu-g++-6 GOOS=linux GOARCH=ppc64le CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
       fi
-      CC=powerpc64le-linux-gnu-gcc-6 CXX=powerpc64le-linux-gnu-g++-6 GOOS=linux GOARCH=ppc64le CGO_ENABLED=1 go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-linux-ppc64le`extension linux`" $PACK_RELPATH
+      CC=powerpc64le-linux-gnu-gcc-6 CXX=powerpc64le-linux-gnu-g++-6 GOOS=linux GOARCH=ppc64le CGO_ENABLED=1 go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" "$BM" -o "/build/$NAME-linux-ppc64le$(extension linux)" "$PACK_RELPATH"
     fi
   fi
-  if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "mipsle" ]); then
+  if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "mipsle" ]; }; then
     if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 18 ]; }; then
       echo "Go version too low, skipping linux/mipsle..."
     else
       echo "Compiling for linux/mipsle..."
-      CC=mipsel-linux-gnu-gcc-6 CXX=mipsel-linux-gnu-g++-6 HOST=mipsel-linux-gnu PREFIX=/usr/mipsel-linux-gnu $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=mipsel-linux-gnu-gcc-6 CXX=mipsel-linux-gnu-g++-6 HOST=mipsel-linux-gnu PREFIX=/usr/mipsel-linux-gnu $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
       export PKG_CONFIG_PATH=/usr/mipsle-linux-gnu/lib/pkgconfig
 
       if [[ "$USEMODULES" == false ]]; then
-        CC=mipsel-linux-gnu-gcc-6 CXX=mipsel-linux-gnu-g++-6 GOOS=linux GOARCH=mipsle CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+        CC=mipsel-linux-gnu-gcc-6 CXX=mipsel-linux-gnu-g++-6 GOOS=linux GOARCH=mipsle CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
       fi
-      CC=mipsel-linux-gnu-gcc-6 CXX=mipsel-linux-gnu-g++-6 GOOS=linux GOARCH=mipsle CGO_ENABLED=1 go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-linux-mipsle`extension linux`" $PACK_RELPATH
+      CC=mipsel-linux-gnu-gcc-6 CXX=mipsel-linux-gnu-g++-6 GOOS=linux GOARCH=mipsle CGO_ENABLED=1 go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" "$BM" -o "/build/$NAME-linux-mipsle$(extension linux)" "$PACK_RELPATH"
     fi
   fi
   # Check and build for Windows targets
-  if [ $XGOOS == "." ] || [[ $XGOOS == windows* ]]; then
+  if [ "$XGOOS" == "." ] || [[ "$XGOOS" == windows* ]]; then
     # Split the platform version and configure the Windows NT version
-    PLATFORM=`echo $XGOOS | cut -d '-' -f 2`
+    PLATFORM=$(echo "$XGOOS" | cut -d '-' -f 2)
     if [ "$PLATFORM" == "" ] || [ "$PLATFORM" == "." ] || [ "$PLATFORM" == "windows" ]; then
       PLATFORM=4.0 # Windows NT
     fi
 
-    MAJOR=`echo $PLATFORM | cut -d '.' -f 1`
+    MAJOR=$(echo "$PLATFORM" | cut -d '.' -f 1)
     if [ "${PLATFORM/.}" != "$PLATFORM" ] ; then
-      MINOR=`echo $PLATFORM | cut -d '.' -f 2`
+      MINOR=$(echo "$PLATFORM" | cut -d '.' -f 2)
     fi
-    CGO_NTDEF="-D_WIN32_WINNT=0x`printf "%02d" $MAJOR``printf "%02d" $MINOR`"
+    CGO_NTDEF="-D_WIN32_WINNT=0x$(printf "%02d" "$MAJOR")$(printf "%02d" "$MINOR")"
 
     # Build the requested windows binaries
-    if [ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]; then
+    if [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "amd64" ]; then
       echo "Compiling for windows-$PLATFORM/amd64..."
-      CC=x86_64-w64-mingw32-gcc-posix CXX=x86_64-w64-mingw32-g++-posix HOST=x86_64-w64-mingw32 PREFIX=/usr/x86_64-w64-mingw32 $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=x86_64-w64-mingw32-gcc-posix CXX=x86_64-w64-mingw32-g++-posix HOST=x86_64-w64-mingw32 PREFIX=/usr/x86_64-w64-mingw32 $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
       export PKG_CONFIG_PATH=/usr/x86_64-w64-mingw32/lib/pkgconfig
 
       if [[ "$USEMODULES" == false ]]; then
-        CC=x86_64-w64-mingw32-gcc-posix CXX=x86_64-w64-mingw32-g++-posix GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+        CC=x86_64-w64-mingw32-gcc-posix CXX=x86_64-w64-mingw32-g++-posix GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
       fi
-      CC=x86_64-w64-mingw32-gcc-posix CXX=x86_64-w64-mingw32-g++-posix GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $R $BM -o "/build/$NAME-windows-$PLATFORM-amd64$R`extension windows`" $PACK_RELPATH
+      CC=x86_64-w64-mingw32-gcc-posix CXX=x86_64-w64-mingw32-g++-posix GOOS=windows GOARCH=amd64 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $R "$BM" -o "/build/$NAME-windows-$PLATFORM-amd64$R$(extension windows)" "$PACK_RELPATH"
     fi
-    if [ $XGOARCH == "." ] || [ $XGOARCH == "386" ]; then
+    if [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "386" ]; then
       echo "Compiling for windows-$PLATFORM/386..."
-      CC=i686-w64-mingw32-gcc-posix CXX=i686-w64-mingw32-g++-posix HOST=i686-w64-mingw32 PREFIX=/usr/i686-w64-mingw32 $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=i686-w64-mingw32-gcc-posix CXX=i686-w64-mingw32-g++-posix HOST=i686-w64-mingw32 PREFIX=/usr/i686-w64-mingw32 $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
       export PKG_CONFIG_PATH=/usr/i686-w64-mingw32/lib/pkgconfig
 
       if [[ "$USEMODULES" == false ]]; then
-        CC=i686-w64-mingw32-gcc-posix CXX=i686-w64-mingw32-g++-posix GOOS=windows GOARCH=386 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
+        CC=i686-w64-mingw32-gcc-posix CXX=i686-w64-mingw32-g++-posix GOOS=windows GOARCH=386 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
       fi
-      CC=i686-w64-mingw32-gcc-posix CXX=i686-w64-mingw32-g++-posix GOOS=windows GOARCH=386 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-windows-$PLATFORM-386`extension windows`" $PACK_RELPATH
+      CC=i686-w64-mingw32-gcc-posix CXX=i686-w64-mingw32-g++-posix GOOS=windows GOARCH=386 CGO_ENABLED=1 CGO_CFLAGS="$CGO_NTDEF" CGO_CXXFLAGS="$CGO_NTDEF" go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" "$BM" -o "/build/$NAME-windows-$PLATFORM-386$(extension windows)" "$PACK_RELPATH"
     fi
   fi
   # Check and build for OSX targets
-  if [ $XGOOS == "." ] || [[ $XGOOS == darwin* ]]; then
+  if [ "$XGOOS" == "." ] || [[ "$XGOOS" == darwin* ]]; then
     # Split the platform version and configure the deployment target
-    PLATFORM=`echo $XGOOS | cut -d '-' -f 2`
+    PLATFORM=$(echo "$XGOOS" | cut -d '-' -f 2)
     if [ "$PLATFORM" == "" ] || [ "$PLATFORM" == "." ] || [ "$PLATFORM" == "darwin" ]; then
       PLATFORM=10.12 # OS X Sierra (min version support for golang)
     fi
@@ -433,24 +437,24 @@ for TARGET in $TARGETS; do
       LDSTRIP="-s"
     fi
     # Build the requested darwin binaries
-    if [ $XGOARCH == "." ] || [ $XGOARCH == "amd64" ]; then
+    if [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "amd64" ]; then
       echo "Compiling for darwin-$PLATFORM/amd64..."
-      CC=o64-clang CXX=o64-clang++ HOST=x86_64-apple-darwin15 PREFIX=/usr/local $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+      CC=o64-clang CXX=o64-clang++ HOST=x86_64-apple-darwin15 PREFIX=/usr/local $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
       if [[ "$USEMODULES" == false ]]; then
-        CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$LDSTRIP $V $LD" --gcflags="$GC" -d $PACK_RELPATH
+        CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$LDSTRIP $V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
       fi
-      CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build $V $X $TP $MOD "${T[@]}" --ldflags="$LDSTRIP $V $LD" --gcflags="$GC" $R $BM -o "/build/$NAME-darwin-$PLATFORM-amd64$R`extension darwin`" $PACK_RELPATH
+      CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$LDSTRIP $V $LD" --gcflags="$GC" $R "$BM" -o "/build/$NAME-darwin-$PLATFORM-amd64$R$(extension darwin)" "$PACK_RELPATH"
     fi
-    if [ $XGOARCH == "." ] || [ $XGOARCH == "arm64" ]; then
+    if [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "arm64" ]; then
       if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 16 ]; }; then
         echo "Go version too low, skipping darwin-$PLATFORM/arm64..."
       else
         echo "Compiling for darwin-$PLATFORM/arm64..."
-        CC=o64-clang CXX=o64-clang++ HOST=arm64-apple-darwin15 PREFIX=/usr/local $BUILD_DEPS /deps ${DEPS_ARGS[@]}
+        CC=o64-clang CXX=o64-clang++ HOST=arm64-apple-darwin15 PREFIX=/usr/local $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
         if [[ "$USEMODULES" == false ]]; then
-          CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$LDSTRIP $V $LD" --gcflags="$GC" -d $PACK_RELPATH
+          CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go get $V $X "${T[@]}" --ldflags="$LDSTRIP $V $LD" --gcflags="$GC" -d "$PACK_RELPATH"
         fi
-        CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build $V $X $TP $MOD "${T[@]}" --ldflags="$LDSTRIP $V $LD" --gcflags="$GC" $R $BM -o "/build/$NAME-darwin-$PLATFORM-arm64$R`extension darwin`" $PACK_RELPATH
+        CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 go build $V $X $TP "$MOD" "${T[@]}" --ldflags="$LDSTRIP $V $LD" --gcflags="$GC" $R "$BM" -o "/build/$NAME-darwin-$PLATFORM-arm64$R$(extension darwin)" "$PACK_RELPATH"
       fi
     fi
     # Remove any automatically injected deployment target vars
@@ -462,18 +466,18 @@ done
 echo "Cleaning up build environment..."
 rm -rf /deps
 
-for dir in `ls /usr/local`; do
+for dir in /usr/local/*; do
   keep=0
 
   # Check against original folder contents
-  for old in $USR_LOCAL_CONTENTS; do
+  for old in "${USR_LOCAL_CONTENTS[@]}"; do
     if [ "$old" == "$dir" ]; then
       keep=1
     fi
   done
   # Delete anything freshly generated
   if [ "$keep" == "0" ]; then
-    rm -rf "/usr/local/$dir"
+    rm -rf "$dir"
   fi
 done
 

--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -48,11 +48,23 @@ function extension {
   fi
 }
 
+GO_VERSION_MAJOR=$(go version | sed -e 's/.*go\([0-9]\+\)\..*/\1/')
+GO_VERSION_MINOR=$(go version | sed -e 's/.*go[0-9]\+\.\([0-9]\+\)\..*/\1/')
+GO111MODULE=$(go env GO111MODULE)
+
 # Detect if we are using go modules
-if [[ "$GO111MODULE" == "on" || "$GO111MODULE" == "auto" ]]; then
-  USEMODULES=true
+if [[ "$GO_VERSION_MAJOR" -le 1 && "$GO_VERSION_MINOR" -le 17 ]]; then
+  if [[ "$GO111MODULE" == "on" || "$GO111MODULE" == "auto" ]]; then
+    USEMODULES=true
+  else
+    USEMODULES=false
+  fi
 else
-  USEMODULES=false
+  if [[ "$GO111MODULE" != "off" ]]; then
+    USEMODULES=true
+  else
+    USEMODULES=false
+  fi
 fi
 
 # Either set a local build environemnt, or pull any remote imports

--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -22,7 +22,6 @@
 #   FLAG_BUILDMODE - Optional buildmode flag to set on the Go builder
 #   FLAG_TRIMPATH  - Optional trimpath flag to set on the Go builder
 #   TARGETS        - Comma separated list of build targets to compile for
-#   GO_VERSION     - Bootstrapped version of Go to disable unsupported targets
 #   EXT_GOPATH     - GOPATH elements mounted from the host filesystem
 
 # Define a function that figures out the binary extension
@@ -214,7 +213,7 @@ for TARGET in $TARGETS; do
     GOOS=linux GOARCH=386 CGO_ENABLED=1 go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-linux-386`extension linux`" $PACK_RELPATH
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "arm" ] || [ $XGOARCH == "arm-5" ]); then
-    if [ "$GO_VERSION" -ge 150 ]; then
+    if [ "$GO_VERSION_MAJOR" -gt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -ge 15 ]; }; then
       echo "Bootstrapping linux/arm-5..."
       CC=arm-linux-gnueabi-gcc-6 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go install std
     fi
@@ -226,13 +225,13 @@ for TARGET in $TARGETS; do
       CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go get $V $X "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" -d $PACK_RELPATH
     fi
     CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go build $V $X $TP $MOD "${T[@]}" --ldflags="$V $LD" --gcflags="$GC" $BM -o "/build/$NAME-linux-arm-5`extension linux`" $PACK_RELPATH
-    if [ "$GO_VERSION" -ge 150 ]; then
+    if [ "$GO_VERSION_MAJOR" -gt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -ge 15 ]; }; then
       echo "Cleaning up Go runtime for linux/arm-5..."
       rm -rf /usr/local/go/pkg/linux_arm
     fi
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "arm-6" ]); then
-    if [ "$GO_VERSION" -lt 150 ]; then
+    if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 15 ]; }; then
       echo "Go version too low, skipping linux/arm-6..."
     else
       echo "Bootstrapping linux/arm-6..."
@@ -252,7 +251,7 @@ for TARGET in $TARGETS; do
     fi
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "arm-7" ]); then
-    if [ "$GO_VERSION" -lt 150 ]; then
+    if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 15 ]; }; then
       echo "Go version too low, skipping linux/arm-7..."
     else
       echo "Bootstrapping linux/arm-7..."
@@ -272,7 +271,7 @@ for TARGET in $TARGETS; do
     fi
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "arm64" ]); then
-    if [ "$GO_VERSION" -lt 150 ]; then
+    if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 15 ]; }; then
       echo "Go version too low, skipping linux/arm64..."
     else
       echo "Compiling for linux/arm64..."
@@ -286,7 +285,7 @@ for TARGET in $TARGETS; do
     fi
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "mips64" ]); then
-    if [ "$GO_VERSION" -lt 170 ]; then
+    if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 17 ]; }; then
       echo "Go version too low, skipping linux/mips64..."
     else
       echo "Compiling for linux/mips64..."
@@ -300,7 +299,7 @@ for TARGET in $TARGETS; do
     fi
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "mips64le" ]); then
-    if [ "$GO_VERSION" -lt 170 ]; then
+    if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 17 ]; }; then
       echo "Go version too low, skipping linux/mips64le..."
     else
       echo "Compiling for linux/mips64le..."
@@ -314,7 +313,7 @@ for TARGET in $TARGETS; do
     fi
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "mips" ]); then
-    if [ "$GO_VERSION" -lt 180 ]; then
+    if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 18 ]; }; then
       echo "Go version too low, skipping linux/mips..."
     else
       echo "Compiling for linux/mips..."
@@ -328,7 +327,7 @@ for TARGET in $TARGETS; do
     fi
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "s390x" ]); then
-    if [ "$GO_VERSION" -lt 170 ]; then
+    if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 17 ]; }; then
       echo "Go version too low, skipping linux/s390x..."
     else
       echo "Compiling for linux/s390x..."
@@ -342,7 +341,7 @@ for TARGET in $TARGETS; do
     fi
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "riscv64" ]); then
-    if [ "$GO_VERSION" -lt 180 ]; then
+    if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 18 ]; }; then
       echo "Go version too low, skipping linux/riscv64..."
     else
       echo "Compiling for linux/riscv64..."
@@ -356,7 +355,7 @@ for TARGET in $TARGETS; do
     fi
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "ppc64le" ]); then
-    if [ "$GO_VERSION" -lt 170 ]; then
+    if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 17 ]; }; then
       echo "Go version too low, skipping linux/ppc64le..."
     else
       echo "Compiling for linux/ppc64le..."
@@ -370,7 +369,7 @@ for TARGET in $TARGETS; do
     fi
   fi
   if ([ $XGOOS == "." ] || [ $XGOOS == "linux" ]) && ([ $XGOARCH == "." ] || [ $XGOARCH == "mipsle" ]); then
-    if [ "$GO_VERSION" -lt 180 ]; then
+    if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 18 ]; }; then
       echo "Go version too low, skipping linux/mipsle..."
     else
       echo "Compiling for linux/mipsle..."
@@ -430,7 +429,7 @@ for TARGET in $TARGETS; do
 
     # Strip symbol table below Go 1.6 to prevent DWARF issues
     LDSTRIP=""
-    if [ "$GO_VERSION" -lt 160 ]; then
+    if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 16 ]; }; then
       LDSTRIP="-s"
     fi
     # Build the requested darwin binaries
@@ -443,7 +442,7 @@ for TARGET in $TARGETS; do
       CC=o64-clang CXX=o64-clang++ GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 go build $V $X $TP $MOD "${T[@]}" --ldflags="$LDSTRIP $V $LD" --gcflags="$GC" $R $BM -o "/build/$NAME-darwin-$PLATFORM-amd64$R`extension darwin`" $PACK_RELPATH
     fi
     if [ $XGOARCH == "." ] || [ $XGOARCH == "arm64" ]; then
-      if [[ "$GO_VERSION" == 115* ]]; then
+      if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 16 ]; }; then
         echo "Go version too low, skipping darwin-$PLATFORM/arm64..."
       else
         echo "Compiling for darwin-$PLATFORM/arm64..."


### PR DESCRIPTION
Go changed the way GO111MODULES is interpreted in 1.17+ and therefore xgo needs to recognise this change of behaviour. 

Now, we could use the GO_VERSION environment variable but it's not really well defined as the build.sh script has apparently different interpretations within it. Thus this PR actually drops to parsing the result of `go version` to get the MAJOR and the MINOR version number out. The tests that use GO_VERSION are then changed to heed the results of these and the GO111MODULES behaviour is changed to match that.

Finally there were a number of issues detected with shellcheck in the scripts and this PR fixes the lint for these too.

(This PR could be split in two if necessary to helpfully separate the linting issues from the other fixes.)

Fix #179