### PR TITLE
Bootstrap arm-5, 6 and 7 in bootstrap-pure not build.sh

### DIFF
--- a/docker/base/bootstrap_pure.sh
+++ b/docker/base/bootstrap_pure.sh
@@ -66,10 +66,27 @@ GOOS=freebsd GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-pc-freebsd12-gcc go install st
 echo "Bootstrapping darwin/amd64..."
 GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 CC=o64-clang go install std
 
-if [[ "$GO_VERSION" != 115* ]]; then
+GO_VERSION_MAJOR=$(go version | sed -e 's/.*go\([0-9]\+\)\..*/\1/')
+GO_VERSION_MINOR=$(go version | sed -e 's/.*go[0-9]\+\.\([0-9]\+\)\..*/\1/')
+
+if [ "$GO_VERSION_MAJOR" -gt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -gt 15 ]; }; then
   echo "Bootstrapping darwin/arm64..."
   GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 CC=o64-clang go install std
+
+  echo "Bootstrapping linux/arm-5..."
+  CC=arm-linux-gnueabi-gcc-6 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go install std
+  mv /usr/local/go/pkg/linux_arm /usr/local/go/pkg/linux_arm-5
+
+  echo "Bootstrapping linux/arm-6..."
+  CC=arm-linux-gnueabi-gcc-6 GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=1 CGO_CFLAGS="-march=armv6" CGO_CXXFLAGS="-march=armv6" go install std
+  mv /usr/local/go/pkg/linux_arm /usr/local/go/pkg/linux_arm-6
+
+  echo "Bootstrapping linux/arm-7..."
+  CC=arm-linux-gnueabihf-gcc-6 GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="-march=armv7-a" CGO_CXXFLAGS="-march=armv7-a" go install std
+  mv /usr/local/go/pkg/linux_arm /usr/local/go/pkg/linux_arm-7
+
 fi
+
 
 # Install xgo within the container to enable internal cross compilation
 echo "Installing xgo-in-xgo..."

--- a/docker/base/bootstrap_pure.sh
+++ b/docker/base/bootstrap_pure.sh
@@ -66,27 +66,20 @@ GOOS=freebsd GOARCH=amd64 CGO_ENABLED=1 CC=x86_64-pc-freebsd12-gcc go install st
 echo "Bootstrapping darwin/amd64..."
 GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 CC=o64-clang go install std
 
-GO_VERSION_MAJOR=$(go version | sed -e 's/.*go\([0-9]\+\)\..*/\1/')
-GO_VERSION_MINOR=$(go version | sed -e 's/.*go[0-9]\+\.\([0-9]\+\)\..*/\1/')
+echo "Bootstrapping darwin/arm64..."
+GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 CC=o64-clang go install std
 
-if [ "$GO_VERSION_MAJOR" -gt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -gt 15 ]; }; then
-  echo "Bootstrapping darwin/arm64..."
-  GOOS=darwin GOARCH=arm64 CGO_ENABLED=1 CC=o64-clang go install std
+echo "Bootstrapping linux/arm-5..."
+CC=arm-linux-gnueabi-gcc-6 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go install std
+mv /usr/local/go/pkg/linux_arm /usr/local/go/pkg/linux_arm-5
 
-  echo "Bootstrapping linux/arm-5..."
-  CC=arm-linux-gnueabi-gcc-6 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go install std
-  mv /usr/local/go/pkg/linux_arm /usr/local/go/pkg/linux_arm-5
+echo "Bootstrapping linux/arm-6..."
+CC=arm-linux-gnueabi-gcc-6 GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=1 CGO_CFLAGS="-march=armv6" CGO_CXXFLAGS="-march=armv6" go install std
+mv /usr/local/go/pkg/linux_arm /usr/local/go/pkg/linux_arm-6
 
-  echo "Bootstrapping linux/arm-6..."
-  CC=arm-linux-gnueabi-gcc-6 GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=1 CGO_CFLAGS="-march=armv6" CGO_CXXFLAGS="-march=armv6" go install std
-  mv /usr/local/go/pkg/linux_arm /usr/local/go/pkg/linux_arm-6
-
-  echo "Bootstrapping linux/arm-7..."
-  CC=arm-linux-gnueabihf-gcc-6 GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="-march=armv7-a" CGO_CXXFLAGS="-march=armv7-a" go install std
-  mv /usr/local/go/pkg/linux_arm /usr/local/go/pkg/linux_arm-7
-
-fi
-
+echo "Bootstrapping linux/arm-7..."
+CC=arm-linux-gnueabihf-gcc-6 GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="-march=armv7-a" CGO_CXXFLAGS="-march=armv7-a" go install std
+mv /usr/local/go/pkg/linux_arm /usr/local/go/pkg/linux_arm-7
 
 # Install xgo within the container to enable internal cross compilation
 echo "Installing xgo-in-xgo..."

--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -218,8 +218,7 @@ for TARGET in $TARGETS; do
   fi
   if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; }  && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "arm" ] || [ "$XGOARCH" == "arm-5" ]; }; then
     if [ "$GO_VERSION_MAJOR" -gt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -ge 15 ]; }; then
-      echo "Bootstrapping linux/arm-5..."
-      CC=arm-linux-gnueabi-gcc-6 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go install std
+      ln -s /usr/local/go/pkg/linux_arm-5 /usr/local/go/pkg/linux_arm
     fi
     echo "Compiling for linux/arm-5..."
     CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 HOST=arm-linux-gnueabi PREFIX=/usr/arm-linux-gnueabi CFLAGS="-march=armv5" CXXFLAGS="-march=armv5" $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
@@ -230,16 +229,14 @@ for TARGET in $TARGETS; do
     fi
     CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=1 CGO_CFLAGS="-march=armv5" CGO_CXXFLAGS="-march=armv5" go build $V $X $TP "${MOD[@]}" "${T[@]}" "${LDF[@]}" "${GC[@]}" "${BM[@]}" -o "/build/$NAME-linux-arm-5$(extension linux)" "$PACK_RELPATH"
     if [ "$GO_VERSION_MAJOR" -gt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -ge 15 ]; }; then
-      echo "Cleaning up Go runtime for linux/arm-5..."
-      rm -rf /usr/local/go/pkg/linux_arm
+      rm /usr/local/go/pkg/linux_arm
     fi
   fi
   if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "arm-6" ]; }; then
     if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 15 ]; }; then
       echo "Go version too low, skipping linux/arm-6..."
     else
-      echo "Bootstrapping linux/arm-6..."
-      CC=arm-linux-gnueabi-gcc-6 GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=1 CGO_CFLAGS="-march=armv6" CGO_CXXFLAGS="-march=armv6" go install std
+      ln -s /usr/local/go/pkg/linux_arm-6 /usr/local/go/pkg/linux_arm
 
       echo "Compiling for linux/arm-6..."
       CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 HOST=arm-linux-gnueabi PREFIX=/usr/arm-linux-gnueabi CFLAGS="-march=armv6" CXXFLAGS="-march=armv6" $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
@@ -250,16 +247,14 @@ for TARGET in $TARGETS; do
       fi
       CC=arm-linux-gnueabi-gcc-6 CXX=arm-linux-gnueabi-g++-6 GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=1 CGO_CFLAGS="-march=armv6" CGO_CXXFLAGS="-march=armv6" go build $V $X $TP "${MOD[@]}" "${T[@]}" "${LDF[@]}" "${GC[@]}" "${BM[@]}" -o "/build/$NAME-linux-arm-6$(extension linux)" "$PACK_RELPATH"
 
-      echo "Cleaning up Go runtime for linux/arm-6..."
-      rm -rf /usr/local/go/pkg/linux_arm
+      rm /usr/local/go/pkg/linux_arm
     fi
   fi
   if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "arm-7" ]; }; then
     if [ "$GO_VERSION_MAJOR" -lt 1 ] || { [ "$GO_VERSION_MAJOR" == 1 ] && [ "$GO_VERSION_MINOR" -lt 15 ]; }; then
       echo "Go version too low, skipping linux/arm-7..."
     else
-      echo "Bootstrapping linux/arm-7..."
-      CC=arm-linux-gnueabihf-gcc-6 GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="-march=armv7-a" CGO_CXXFLAGS="-march=armv7-a" go install std
+      ln -s /usr/local/go/pkg/linux_arm-7 /usr/local/go/pkg/linux_arm
 
       echo "Compiling for linux/arm-7..."
       CC=arm-linux-gnueabihf-gcc-6 CXX=arm-linux-gnueabihf-g++-6 HOST=arm-linux-gnueabihf PREFIX=/usr/arm-linux-gnueabihf CFLAGS="-march=armv7-a -fPIC" CXXFLAGS="-march=armv7-a -fPIC" $BUILD_DEPS /deps "${DEPS_ARGS[@]}"
@@ -270,8 +265,7 @@ for TARGET in $TARGETS; do
       fi
       CC=arm-linux-gnueabihf-gcc-6 CXX=arm-linux-gnueabihf-g++-6 GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=1 CGO_CFLAGS="-march=armv7-a -fPIC" CGO_CXXFLAGS="-march=armv7-a -fPIC" go build $V $X $TP "${MOD[@]}" "${T[@]}" "${LDF[@]}" "${GC[@]}" "${BM[@]}" -o "/build/$NAME-linux-arm-7$(extension linux)" "$PACK_RELPATH"
 
-      echo "Cleaning up Go runtime for linux/arm-7..."
-      rm -rf /usr/local/go/pkg/linux_arm
+      rm /usr/local/go/pkg/linux_arm
     fi
   fi
   if { [ "$XGOOS" == "." ] || [ "$XGOOS" == "linux" ]; } && { [ "$XGOARCH" == "." ] || [ "$XGOARCH" == "arm64" ]; }; then


### PR DESCRIPTION
Bootstrapping of arm-5, -6 and -7 currently happens in build.sh because Go will install std to /usr/local/go/pkg/linux_arm. This PR simply bootstraps these in bootstrap and moves them to /usr/local/go/pkg/linux_arm-x as appropriate with build.sh creating a symbolic link as needed.

This should slightly speed up arm builds using xgo.

Signed-off-by: Andrew Thornton <art27@cantab.net>