### PR TITLE
Fix yet another bug with go-gettable modules

### DIFF
--- a/docker/base/build.sh
+++ b/docker/base/build.sh
@@ -161,7 +161,7 @@ shopt -u nullglob
 NAME="$OUT"
 
 if [ "$NAME" == "" ]; then
-  if [[ "$USEMODULES" = true ]]; then
+  if [[ "$USEMODULES" = true && -d /source && -f /source/go.mod ]]; then
     # Go module-based builds error with 'cannot find main module'
     # when $PACK is defined
     NAME="$(sed -n 's/module\ \(.*\)/\1/p' /source/go.mod)"


### PR DESCRIPTION
There was another bug needing to be fixed in #187 - /source/go.mod does not exist in go-gettable modules therefore the NAME determination will fail.

Fix #187

Signed-off-by: Andrew Thornton <art27@cantab.net>