### PR TITLE
Fix ENTRYPOINT of `toolchain` image

### DIFF
--- a/docker/toolchain/Dockerfile
+++ b/docker/toolchain/Dockerfile
@@ -112,4 +112,4 @@ COPY build_deps.sh /build_deps.sh
 ENV BUILD_DEPS /build_deps.sh
 RUN chmod +x $BUILD_DEPS
 
-ENTRYPOINT [ "/bin/bash" ]
+ENTRYPOINT [ "/bin/bash", "-l", "-c" ]


### PR DESCRIPTION
`"/bin/bash"` is not a valid entrypoint and will result in errors when running the container manually (I know this is usually not needed but helpful for some debugging actions).

The change allows running containers from the image.